### PR TITLE
fix: filter out ignored commands from search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /tmp
 node_modules
 oclif.manifest.json
+.idea/

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -14,7 +14,8 @@ export default class Search extends Command {
   public static description = 'Once you select a command, hit enter and it will show the help for that command.'
 
   public async run(): Promise<unknown> {
-    const commands = this.config.commands as Array<Command.Loadable & { readableId: string }>
+    const commands = (this.config.commands as Array<Command.Loadable & { readableId: string }>).filter(c => !c.hidden)
+
     for (const command of commands) {
       command.readableId = toConfiguredId(command.id, this.config)
     }


### PR DESCRIPTION
@W-14189635@

we should be able to remove them in the `for ... of ...` loop below, but I was getting errors 
```
 ➜  sf search
    TypeError: fuse_js_1.default is not a constructor
```
when trying that.

I was also intermittently getting those errors with this `.filter` approach 🤷‍♂️ 